### PR TITLE
Rewrite profile README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,51 +1,18 @@
-<h1 align='center'>
-  👋 Hi, I'm Domen
-</h1>
+### hey, I'm Domen
 
-<p align="center">
-  <b>Senior Software Engineer | Backend & Cloud Infrastructure</b><br/>
-  📍 Ljubljana, Slovenia
-</p>
+Senior Backend Engineer at [Didomi](https://www.didomi.io/) by day, co-founder of [Pentla](https://pentla.tech) by... also day. Based in Ljubljana, Slovenia.
 
-<p align="center">
-  <a href="https://www.linkedin.com/in/domengabrovsek">
-    <img src="https://img.shields.io/badge/LinkedIn-0077B5?style=for-the-badge&logo=linkedin&logoColor=white"/>
-  </a>
-  <a href="#">
-    <img src="https://komarev.com/ghpvc/?username=domengabrovsek&style=for-the-badge&color=blue"/>
-  </a>
-</p>
+I've spent 10+ years building backend systems and cloud infrastructure. These days my work revolves around privacy and compliance - helping companies handle data responsibly at Didomi, and building something of my own at Pentla.
 
----
+`TypeScript / Node.js` - `AWS / GCP` - `Terraform / CDK`
 
-## What I do
+Certified across Google Cloud and Node.js - [full list on Credly](https://www.credly.com/users/domen-gabrovsek/badges).
 
-I design and build cloud-native systems at scale, with 10+ years of experience in backend development and infrastructure engineering. 
+[![Website](https://img.shields.io/badge/domengabrovsek.com-000?style=flat&logo=safari&logoColor=white)](https://domengabrovsek.com)
+[![LinkedIn](https://img.shields.io/badge/LinkedIn-0077B5?style=flat&logo=linkedin&logoColor=white)](https://www.linkedin.com/in/domengabrovsek)
+[![X](https://img.shields.io/badge/X-000?style=flat&logo=x&logoColor=white)](https://x.com/domengabrovsek)
+[![Bluesky](https://img.shields.io/badge/Bluesky-0285FF?style=flat&logo=bluesky&logoColor=white)](https://bsky.app/profile/domen-gabrovsek.dev)
+[![Chess.com](https://img.shields.io/badge/Chess.com-81B64C?style=flat&logo=chess.com&logoColor=white)](https://www.chess.com/member/domengabrovsek)
+[![Lichess](https://img.shields.io/badge/Lichess-000?style=flat&logo=lichess&logoColor=white)](https://lichess.org/@/domengabrovsek)
 
-Currently working at [Didomi](https://www.didomi.io/) 🔒 building privacy solutions that help organizations navigate complex regulatory landscapes.
-
-I'm passionate about automation, simplification, and writing code that's straightforward to test and maintain. If there's a manual process, I'll find a way to automate it. If there's complexity, I'll work to simplify it.
-
-### What I work with
-
-☁️ AWS • GCP  
-⚡ TypeScript/Node.js  
-🏗️ Terraform/CDK
-
-## How I work
-
-I build production-grade systems that handle scale - from resilient backend services to event-driven architectures and automated infrastructure deployment. My approach emphasizes clean architecture, simple and testable code, and operational excellence.
-
-As a digital privacy enthusiast, I'm particularly interested in building systems that respect user privacy by design while maintaining performance and usability.
-
----
-
-## Certifications
-
-🏆 [View my credentials on Credly](https://www.credly.com/users/domen-gabrovsek/badges)
-
----
-
-💬 Open to discussing distributed systems, cloud architecture, privacy engineering, or infrastructure challenges  
-🤝 I enjoy sharing knowledge and mentoring - if you're a junior engineer or just want to discuss technical topics, feel free to reach out  
-♟️ Chess enthusiast – find me on [Chess.com](https://www.chess.com/member/domengabrovsek) or [Lichess](https://lichess.org/@/domengabrovsek)
+Fun fact: `'())('` is a palindrome. Feel free to reach out about distributed systems, privacy engineering, or chess.


### PR DESCRIPTION
## Summary
- Rewrote the entire profile README to drop corporate/resume tone in favor of something more authentic and concise
- Added Pentla co-founder role (was completely missing)
- Added all social links as flat badges: website, LinkedIn, X, Bluesky, Chess.com, Lichess
- Trimmed from 52 lines to 18 - removed centered HTML, view counter badge, emoji walls, horizontal rules, and buzzword paragraphs
- Added the palindrome joke from the GitHub bio as a closing touch

## Test plan
- [ ] Preview the rendered README on the PR's "Files changed" tab
- [ ] Verify all badge links resolve correctly
- [ ] Check mobile rendering (no wide elements)

🤖 Generated with [Claude Code](https://claude.com/claude-code)