### PR TITLE
docs: link companies, refine badges, remote + closing tweaks

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,8 +1,8 @@
 <h1 align="center">👋 Hi, I'm Domen</h1>
 
 <p align="center">
-  <b>Senior Backend Engineer @ Didomi · Co-founder @ Pentla</b><br/>
-  📍 Ljubljana, Slovenia 🇸🇮
+  <b>Senior Backend Engineer @ <a href="https://www.didomi.io">Didomi</a> · Co-founder @ <a href="https://pentla.tech">Pentla</a></b><br/>
+  📍 Ljubljana, Slovenia 🇸🇮 · 🌐 Remote only
 </p>
 
 <p align="center">
@@ -26,13 +26,23 @@ founding engineer, building the product from the ground up.
 ### What I work with
 
 <p>
-  <img src="https://img.shields.io/badge/TypeScript-3178C6?style=flat-square&logo=typescript&logoColor=white"/>
-  <img src="https://img.shields.io/badge/Node.js-339933?style=flat-square&logo=node.js&logoColor=white"/>
-  <img src="https://img.shields.io/badge/AWS-232F3E?style=flat-square&logo=amazonwebservices&logoColor=white"/>
-  <img src="https://img.shields.io/badge/GCP-4285F4?style=flat-square&logo=googlecloud&logoColor=white"/>
-  <img src="https://img.shields.io/badge/Terraform-7B42BC?style=flat-square&logo=terraform&logoColor=white"/>
-  <img src="https://img.shields.io/badge/Docker-2496ED?style=flat-square&logo=docker&logoColor=white"/>
-  <img src="https://img.shields.io/badge/PostgreSQL-4169E1?style=flat-square&logo=postgresql&logoColor=white"/>
+  <img alt="TypeScript" src="https://img.shields.io/badge/TypeScript-007ACC?style=for-the-badge&logo=typescript&logoColor=white"/>
+  <img alt="Node.js" src="https://img.shields.io/badge/Node.js-6DA55F?style=for-the-badge&logo=node.js&logoColor=white"/>
+  <img alt="NestJS" src="https://img.shields.io/badge/NestJS-E0234E?style=for-the-badge&logo=nestjs&logoColor=white"/>
+  <img alt="Fastify" src="https://img.shields.io/badge/Fastify-000000?style=for-the-badge&logo=fastify&logoColor=white"/>
+  <img alt="React" src="https://img.shields.io/badge/React-20232A?style=for-the-badge&logo=react&logoColor=61DAFB"/>
+</p>
+<p>
+  <img alt="AWS" src="https://img.shields.io/badge/AWS-232F3E?style=for-the-badge&logo=amazonwebservices&logoColor=white"/>
+  <img alt="Google Cloud" src="https://img.shields.io/badge/Google%20Cloud-4285F4?style=for-the-badge&logo=googlecloud&logoColor=white"/>
+  <img alt="Cloudflare" src="https://img.shields.io/badge/Cloudflare-F38020?style=for-the-badge&logo=cloudflare&logoColor=white"/>
+  <img alt="Terraform" src="https://img.shields.io/badge/Terraform-7B42BC?style=for-the-badge&logo=terraform&logoColor=white"/>
+  <img alt="Docker" src="https://img.shields.io/badge/Docker-2496ED?style=for-the-badge&logo=docker&logoColor=white"/>
+</p>
+<p>
+  <img alt="PostgreSQL" src="https://img.shields.io/badge/PostgreSQL-4169E1?style=for-the-badge&logo=postgresql&logoColor=white"/>
+  <img alt="GitHub Actions" src="https://img.shields.io/badge/GitHub%20Actions-2671E5?style=for-the-badge&logo=githubactions&logoColor=white"/>
+  <img alt="Claude" src="https://img.shields.io/badge/Claude-D97757?style=for-the-badge&logo=claude&logoColor=white"/>
 </p>
 
 Day to day that's TypeScript on Node.js, infrastructure as code with Terraform,

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 <p align="center">
   <b>Senior Backend Engineer @ <a href="https://www.didomi.io">Didomi</a> · Co-founder @ <a href="https://pentla.tech">Pentla</a></b><br/>
-  📍 Ljubljana, Slovenia 🇸🇮 · 🌐 Remote only
+  📍 Ljubljana, Slovenia 🇸🇮 · 🌐 Working remotely
 </p>
 
 <p align="center">
@@ -38,11 +38,7 @@ founding engineer, building the product from the ground up.
   <img alt="Cloudflare" src="https://img.shields.io/badge/Cloudflare-F38020?style=for-the-badge&logo=cloudflare&logoColor=white"/>
   <img alt="Terraform" src="https://img.shields.io/badge/Terraform-7B42BC?style=for-the-badge&logo=terraform&logoColor=white"/>
   <img alt="Docker" src="https://img.shields.io/badge/Docker-2496ED?style=for-the-badge&logo=docker&logoColor=white"/>
-</p>
-<p>
   <img alt="PostgreSQL" src="https://img.shields.io/badge/PostgreSQL-4169E1?style=for-the-badge&logo=postgresql&logoColor=white"/>
-  <img alt="GitHub Actions" src="https://img.shields.io/badge/GitHub%20Actions-2671E5?style=for-the-badge&logo=githubactions&logoColor=white"/>
-  <img alt="Claude" src="https://img.shields.io/badge/Claude-D97757?style=for-the-badge&logo=claude&logoColor=white"/>
 </p>
 
 Day to day that's TypeScript on Node.js, infrastructure as code with Terraform,
@@ -70,8 +66,7 @@ AWS & GCP certified - full list on [Credly](https://www.credly.com/users/domen-g
 
 ---
 
-💬 Always happy to talk engineering, privacy, and automation - or chess and
-bikes - and up for mentoring if you're earlier in your journey.
+💬 Happy to talk engineering, privacy, automation, chess, or bikes - always open to sharing knowledge and mentoring.
 
 <p>
   ♟️ <a href="https://www.chess.com/member/domengabrovsek">Chess.com</a> ·


### PR DESCRIPTION
## Summary

- Linked the headline keywords: Didomi -> didomi.io and Pentla -> pentla.tech
- Added "Working remotely" to the location line
- Replaced the flat badge row with bolder for-the-badge style, grouped into two rows
- Expanded the stack from what the repos actually use: added NestJS, Fastify, React, Cloudflare
- Reworded the closing line to a single line about sharing knowledge and mentoring