### PR TITLE
ci: route workflows to air self-hosted runner

### DIFF
--- a/.github/workflows/pull-request.yml
+++ b/.github/workflows/pull-request.yml
@@ -13,7 +13,7 @@ permissions:
 jobs:
   gate:
     name: Gate
-    runs-on: ubuntu-latest
+    runs-on: "${{ vars.CI_RUNNER && fromJSON(vars.CI_RUNNER) || 'ubuntu-latest' }}"
     timeout-minutes: 1
     steps:
       - name: Gate


### PR DESCRIPTION
Routes all CI jobs to the air self-hosted runner via the CI_RUNNER variable switch (ubuntu-latest fallback).